### PR TITLE
Specified exception type to avoid Python specific errors

### DIFF
--- a/previewtest.py
+++ b/previewtest.py
@@ -27,7 +27,7 @@ for i in range(5000):
                 preview.append((int)(zombie_type))
         df["Preview Normals"][i] = preview.count(0)
         df["Preview Cones"][i] = preview.count(2)
-    except:
+    except Exception:
         break
 
 print(i)


### PR DESCRIPTION
The current try/except statements will break on any exception. The pvz module only produces exceptions of type Exception. Therefore, specifying the exception type allows other Python errors to propagate.